### PR TITLE
Fix writeMultipleCoils, readCoils, readInputStatus

### DIFF
--- a/Modbus.cpp
+++ b/Modbus.cpp
@@ -326,7 +326,7 @@ void Modbus::readCoils(word startreg, word numregs) {
     byte bitn = 0;
     word totregs = numregs;
     word i;
-	while (numregs--) {
+	while (numregs) {
         i = (totregs - numregs) / 8;
 		if (this->Coil(startreg))
 			bitSet(_frame[2+i], bitn);
@@ -337,6 +337,7 @@ void Modbus::readCoils(word startreg, word numregs) {
 		if (bitn == 8) bitn = 0;
 		//increment the register
 		startreg++;
+        numregs--;
 	}
 
     _reply = MB_REPLY_NORMAL;
@@ -377,7 +378,7 @@ void Modbus::readInputStatus(word startreg, word numregs) {
     byte bitn = 0;
     word totregs = numregs;
     word i;
-	while (numregs--) {
+	while (numregs) {
         i = (totregs - numregs) / 8;
 		if (this->Ists(startreg))
 			bitSet(_frame[2+i], bitn);
@@ -388,6 +389,7 @@ void Modbus::readInputStatus(word startreg, word numregs) {
 		if (bitn == 8) bitn = 0;
 		//increment the register
 		startreg++;
+        numregs--;
 	}
 
     _reply = MB_REPLY_NORMAL;
@@ -496,7 +498,7 @@ void Modbus::writeMultipleCoils(byte* frame,word startreg, word numoutputs, byte
     byte bitn = 0;
     word totoutputs = numoutputs;
     word i;
-	while (numoutputs--) {
+	while (numoutputs) {
         i = (totoutputs - numoutputs) / 8;
         this->Coil(startreg, bitRead(frame[6+i], bitn));
         //increment the bit index
@@ -504,6 +506,7 @@ void Modbus::writeMultipleCoils(byte* frame,word startreg, word numoutputs, byte
         if (bitn == 8) bitn = 0;
         //increment the register
         startreg++;
+        numoutputs--;
 	}
 
     _reply = MB_REPLY_NORMAL;

--- a/Modbus.cpp
+++ b/Modbus.cpp
@@ -315,6 +315,7 @@ void Modbus::readCoils(word startreg, word numregs) {
     word i;
 	while (numregs) {
         i = (totregs - numregs) / 8;
+        if (bitn == 0) _frame[2+i] = 0; // init Coil status
 		if (this->Coil(startreg))
 			bitSet(_frame[2+i], bitn);
 		else

--- a/Modbus.cpp
+++ b/Modbus.cpp
@@ -172,10 +172,8 @@ void Modbus::receivePDU(byte* frame) {
 }
 
 void Modbus::exceptionResponse(byte fcode, byte excode) {
-    //Clean frame buffer
-    free(_frame);
     _len = 2;
-    _frame = (byte *) malloc(_len);
+
     _frame[0] = fcode + 0x80;
     _frame[1] = excode;
 
@@ -196,16 +194,11 @@ void Modbus::readRegisters(word startreg, word numregs) {
         return;
     }
 
-
-    //Clean frame buffer
-    free(_frame);
-	_len = 0;
-
 	//calculate the query reply message length
 	//for each register queried add 2 bytes
 	_len = 2 + numregs * 2;
 
-    _frame = (byte *) malloc(_len);
+
     if (!_frame) {
         this->exceptionResponse(MB_FC_READ_REGS, MB_EX_SLAVE_FAILURE);
         return;
@@ -261,10 +254,8 @@ void Modbus::writeMultipleRegisters(byte* frame,word startreg, word numoutputs, 
         }
     }
 
-    //Clean frame buffer
-    free(_frame);
 	_len = 5;
-    _frame = (byte *) malloc(_len);
+
     if (!_frame) {
         this->exceptionResponse(MB_FC_WRITE_REGS, MB_EX_SLAVE_FAILURE);
         return;
@@ -305,16 +296,12 @@ void Modbus::readCoils(word startreg, word numregs) {
         return;
     }
 
-    //Clean frame buffer
-    free(_frame);
-	_len = 0;
-
     //Determine the message length = function type, byte count and
 	//for each group of 8 registers the message length increases by 1
 	_len = 2 + numregs/8;
 	if (numregs%8) _len++; //Add 1 to the message length for the partial byte.
 
-    _frame = (byte *) malloc(_len);
+
     if (!_frame) {
         this->exceptionResponse(MB_FC_READ_COILS, MB_EX_SLAVE_FAILURE);
         return;
@@ -357,16 +344,12 @@ void Modbus::readInputStatus(word startreg, word numregs) {
         return;
     }
 
-    //Clean frame buffer
-    free(_frame);
-	_len = 0;
-
     //Determine the message length = function type, byte count and
 	//for each group of 8 registers the message length increases by 1
 	_len = 2 + numregs/8;
 	if (numregs%8) _len++; //Add 1 to the message length for the partial byte.
 
-    _frame = (byte *) malloc(_len);
+
     if (!_frame) {
         this->exceptionResponse(MB_FC_READ_INPUT_STAT, MB_EX_SLAVE_FAILURE);
         return;
@@ -409,15 +392,11 @@ void Modbus::readInputRegisters(word startreg, word numregs) {
         return;
     }
 
-    //Clean frame buffer
-    free(_frame);
-	_len = 0;
-
 	//calculate the query reply message length
 	//for each register queried add 2 bytes
 	_len = 2 + numregs * 2;
 
-    _frame = (byte *) malloc(_len);
+
     if (!_frame) {
         this->exceptionResponse(MB_FC_READ_INPUT_REGS, MB_EX_SLAVE_FAILURE);
         return;
@@ -480,10 +459,8 @@ void Modbus::writeMultipleCoils(byte* frame,word startreg, word numoutputs, byte
         }
     }
 
-    //Clean frame buffer
-    free(_frame);
 	_len = 5;
-    _frame = (byte *) malloc(_len);
+
     if (!_frame) {
         this->exceptionResponse(MB_FC_WRITE_COILS, MB_EX_SLAVE_FAILURE);
         return;
@@ -512,6 +489,3 @@ void Modbus::writeMultipleCoils(byte* frame,word startreg, word numoutputs, byte
     _reply = MB_REPLY_NORMAL;
 }
 #endif
-
-
-

--- a/Modbus.h
+++ b/Modbus.h
@@ -8,7 +8,7 @@
 #define MODBUS_H
 
 #define MAX_REGS     32
-#define MAX_FRAME   128
+#define MAX_FRAME    48
 //#define USE_HOLDING_REGISTERS_ONLY
 
 typedef unsigned int u_int;
@@ -70,7 +70,7 @@ class Modbus {
         word Reg(word address);
 
     protected:
-        byte *_frame;
+        byte  _frame[MAX_FRAME];
         byte  _len;
         byte  _reply;
         void receivePDU(byte* frame);


### PR DESCRIPTION
Coil address (startreg+7) mistakenly mapped to 7th bit of _frame[3] (must be _frame[2] instead)
Coil address (startreg+15) mistakenly mapped to 7th bit of _frame[4] (must be _frame[3] instead)
...
The same bug in readInputStatus.